### PR TITLE
Migrate from unlayer-types to @unlayer/types

### DIFF
--- a/demo/src/example/index.tsx
+++ b/demo/src/example/index.tsx
@@ -3,7 +3,10 @@ import styled from 'styled-components';
 
 import packageJson from '../../../package.json';
 import EmailEditor, { EditorRef, EmailEditorProps } from '../../../src'; // use react-email-editor instead
-import sample from './sample.json';
+import type { JSONTemplate } from '@unlayer/types';
+import _sample from './sample.json';
+
+const sample = _sample as any as JSONTemplate<'email'>;
 
 const Container = styled.div`
   display: flex;
@@ -71,11 +74,12 @@ const Example = () => {
       setPreview(false);
     } else {
       unlayer?.showPreview('desktop');
+      // unlayer?.showPreview({ device: 'desktop', resolution: 1024 })
       setPreview(true);
     }
   };
 
-  const onDesignLoad = (data) => {
+  const onDesignLoad = (data: { design: JSONTemplate<'email'> }) => {
     console.log('onDesignLoad', data);
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.11",
       "license": "MIT",
       "dependencies": {
-        "unlayer-types": "latest"
+        "@unlayer/types": "latest"
       },
       "devDependencies": {
         "@rollup/plugin-replace": "^5.0.2",
@@ -2888,6 +2888,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@unlayer/types": {
+      "version": "1.389.0",
+      "resolved": "https://registry.npmjs.org/@unlayer/types/-/types-1.389.0.tgz",
+      "integrity": "sha512-wf46pNwwrSG0CDPsIoGYEKpmJb3aj/KFq4JOFEZK9/MfWKJFoFN2DX3s2eqiDgpG4gFrwaADjgjsmq4SHb6V5w==",
+      "license": "MIT"
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -12019,11 +12025,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/unlayer-types": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/unlayer-types/-/unlayer-types-1.47.0.tgz",
-      "integrity": "sha512-FahED+IKCtkpeXFC/q7rqfpdVbVIbdyDdIEnmjIKHJBqsQ/WZAqNsethE4IEWXJa1zm4bDqVrELQ8gHwPh8Jrw=="
-    },
     "node_modules/unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -14535,6 +14536,11 @@
         }
       }
     },
+    "@unlayer/types": {
+      "version": "1.389.0",
+      "resolved": "https://registry.npmjs.org/@unlayer/types/-/types-1.389.0.tgz",
+      "integrity": "sha512-wf46pNwwrSG0CDPsIoGYEKpmJb3aj/KFq4JOFEZK9/MfWKJFoFN2DX3s2eqiDgpG4gFrwaADjgjsmq4SHb6V5w=="
+    },
     "abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -14569,7 +14575,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -14865,13 +14872,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.4.0.tgz",
       "integrity": "sha512-oi4M/PWUJOU9ZyRGoPTfPMqdyMp06jbJAomd3RcyYuzUtBOddv98BqLm96Lucpi2QFoQHkdGQt0ACvw7VzVEQA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-plugin-dev-expression": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.3.tgz",
       "integrity": "sha512-rP5LK9QQTzCW61nVVzw88En1oK8t8gTsIeC6E61oelxNsU842yMjF0G1MxhvUpCkxCEIj7sE8/e5ieTheT//uw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-plugin-istanbul": {
       "version": "6.1.1",
@@ -16167,7 +16176,8 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz",
       "integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -17823,7 +17833,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "25.2.6",
@@ -21109,11 +21120,6 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
-    "unlayer-types": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/unlayer-types/-/unlayer-types-1.47.0.tgz",
-      "integrity": "sha512-FahED+IKCtkpeXFC/q7rqfpdVbVIbdyDdIEnmjIKHJBqsQ/WZAqNsethE4IEWXJa1zm4bDqVrELQ8gHwPh8Jrw=="
-    },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -21449,7 +21455,8 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "unlayer-types": "latest"
+    "@unlayer/types": "latest"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.2",

--- a/src/EmailEditor.tsx
+++ b/src/EmailEditor.tsx
@@ -4,7 +4,7 @@ import React, {
   useImperativeHandle,
   useMemo,
 } from 'react';
-import type { UnlayerEditor } from '@unlayer/types';
+import type { DisplayMode, UnlayerEditor } from '@unlayer/types';
 
 import pkg from '../package.json';
 import { EditorRef, EmailEditorProps } from './types';
@@ -13,11 +13,13 @@ import { loadScript } from './loadScript';
 const win = typeof window === 'undefined' ? { __unlayer_lastEditorId: 0 } : window
 win.__unlayer_lastEditorId = win.__unlayer_lastEditorId || 0;
 
-export const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
-  (props, ref) => {
+function EmailEditorInner<TDisplayMode extends DisplayMode | undefined = 'email'>(
+  props: EmailEditorProps<TDisplayMode>,
+  ref: React.Ref<EditorRef<TDisplayMode>>,
+) {
     const { onLoad, onReady, scriptUrl, minHeight = 500, style = {} } = props;
 
-    const [editor, setEditor] = useState<UnlayerEditor | null>(null);
+    const [editor, setEditor] = useState<UnlayerEditor<TDisplayMode> | null>(null);
 
     const [hasLoadedEmbedScript, setHasLoadedEmbedScript] = useState(false);
 
@@ -26,10 +28,10 @@ export const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
       [props.editorId]
     );
 
-    const options: EmailEditorProps['options'] = {
+    const options = {
       ...(props.options || {}),
       appearance: props.appearance ?? props.options?.appearance,
-      displayMode: props?.displayMode || props.options?.displayMode || 'email',
+      displayMode: props?.displayMode || props.options?.displayMode || 'email' as const,
       locale: props.locale ?? props.options?.locale,
       projectId: props.projectId ?? props.options?.projectId,
       tools: props.tools ?? props.options?.tools,
@@ -104,5 +106,10 @@ export const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
         <div id={editorId} style={{ ...style, flex: 1 }} />
       </div>
     );
-  }
-);
+}
+
+export const EmailEditor = React.forwardRef(EmailEditorInner) as <
+  TDisplayMode extends DisplayMode | undefined = 'email',
+>(
+  props: EmailEditorProps<TDisplayMode> & React.RefAttributes<EditorRef<TDisplayMode>>,
+) => React.ReactElement | null;

--- a/src/EmailEditor.tsx
+++ b/src/EmailEditor.tsx
@@ -4,9 +4,10 @@ import React, {
   useImperativeHandle,
   useMemo,
 } from 'react';
+import type { UnlayerEditor } from '@unlayer/types';
 
 import pkg from '../package.json';
-import { Editor, EditorRef, EmailEditorProps } from './types';
+import { EditorRef, EmailEditorProps } from './types';
 import { loadScript } from './loadScript';
 
 const win = typeof window === 'undefined' ? { __unlayer_lastEditorId: 0 } : window
@@ -16,7 +17,7 @@ export const EmailEditor = React.forwardRef<EditorRef, EmailEditorProps>(
   (props, ref) => {
     const { onLoad, onReady, scriptUrl, minHeight = 500, style = {} } = props;
 
-    const [editor, setEditor] = useState<Editor | null>(null);
+    const [editor, setEditor] = useState<UnlayerEditor | null>(null);
 
     const [hasLoadedEmbedScript, setHasLoadedEmbedScript] = useState(false);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,24 +9,24 @@ import type {
   UnlayerOptions,
 } from '@unlayer/types';
 
-export interface EditorRef {
-  editor: UnlayerEditor | null;
+export interface EditorRef<TDisplayMode extends DisplayMode | undefined = 'email'> {
+  editor: UnlayerEditor<TDisplayMode> | null;
 }
 
-export interface EmailEditorProps {
+export interface EmailEditorProps<TDisplayMode extends DisplayMode | undefined = 'email'> {
   editorId?: string | undefined;
   minHeight?: number | string | undefined;
-  onLoad?(unlayer: UnlayerEditor): void;
-  onReady?(unlayer: UnlayerEditor): void;
-  options?: UnlayerOptions | undefined;
+  onLoad?(unlayer: UnlayerEditor<TDisplayMode>): void;
+  onReady?(unlayer: UnlayerEditor<TDisplayMode>): void;
+  options?: Omit<UnlayerOptions, 'displayMode'> & { displayMode?: TDisplayMode };
   scriptUrl?: string | undefined;
   style?: CSSProperties | undefined;
 
   // redundant props -- already available in options
   /** @deprecated */
   appearance?: AppearanceConfig | undefined;
-  /** @deprecated */
-  displayMode?: DisplayMode;
+  /** @deprecated Use options.displayMode instead */
+  displayMode?: TDisplayMode;
   /** @deprecated */
   locale?: string | undefined;
   /** @deprecated */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,24 +1,23 @@
-/// <reference path="../node_modules/unlayer-types/embed.d.ts" />
-
 import { CSSProperties } from 'react';
 
-import Embed from 'embed/index';
-import { Editor as EditorClass } from 'embed/Editor';
-import { AppearanceConfig, DisplayMode, ToolsConfig } from 'state/types/types';
-
-export type Unlayer = typeof Embed;
-export type UnlayerOptions = Parameters<Unlayer['createEditor']>[0];
-export type Editor = InstanceType<typeof EditorClass>;
+import type {
+  AppearanceConfig,
+  DisplayMode,
+  ToolsConfig,
+  UnlayerEditor,
+  UnlayerEmbed,
+  UnlayerOptions,
+} from '@unlayer/types';
 
 export interface EditorRef {
-  editor: Editor | null;
+  editor: UnlayerEditor | null;
 }
 
 export interface EmailEditorProps {
   editorId?: string | undefined;
   minHeight?: number | string | undefined;
-  onLoad?(unlayer: Editor): void;
-  onReady?(unlayer: Editor): void;
+  onLoad?(unlayer: UnlayerEditor): void;
+  onReady?(unlayer: UnlayerEditor): void;
   options?: UnlayerOptions | undefined;
   scriptUrl?: string | undefined;
   style?: CSSProperties | undefined;
@@ -37,7 +36,7 @@ export interface EmailEditorProps {
 }
 
 declare global {
-  const unlayer: Unlayer;
+  const unlayer: UnlayerEmbed;
 
   interface Window {
     __unlayer_lastEditorId: number;


### PR DESCRIPTION
Replace the deprecated `unlayer-types` package with the new [@unlayer/types](https://www.npmjs.com/package/@unlayer/types) scoped package. Update `EmailEditor` component and types to support generic `TDisplayMode` parameter for type-safe display mode handling.

Fix #464
Fix #454
Fix #447
Fix #200
Close #448