### PR TITLE
Fix editor lifecycle bugs in EmailEditor

### DIFF
--- a/src/EmailEditor.tsx
+++ b/src/EmailEditor.tsx
@@ -3,6 +3,7 @@ import React, {
   useState,
   useImperativeHandle,
   useMemo,
+  useRef,
 } from 'react';
 import type { DisplayMode, UnlayerEditor } from '@unlayer/types';
 
@@ -51,9 +52,14 @@ function EmailEditorInner<TDisplayMode extends DisplayMode | undefined = 'email'
       [editor]
     );
 
+    // Keep a ref to the latest editor so the unmount cleanup below doesn't
+    // capture the initial (null) state.
+    const editorRef = useRef(editor);
+    editorRef.current = editor;
+
     useEffect(() => {
       return () => {
-        editor?.destroy();
+        editorRef.current?.destroy();
       };
     }, []);
 
@@ -93,7 +99,7 @@ function EmailEditorInner<TDisplayMode extends DisplayMode | undefined = 'email'
           onReady(editor);
         });
       }
-    }, [editor, Object.keys(methodProps).join(',')]);
+    }, [editor, methodProps.join(',')]);
 
     return (
       <div

--- a/test/destroy.test.tsx
+++ b/test/destroy.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Editor from '../src';
+
+jest.mock('../src/loadScript', () => ({
+  loadScript: (callback: Function) => callback(),
+}));
+
+it('destroys the editor on unmount', () => {
+  const destroy = jest.fn();
+  (global as any).unlayer = {
+    createEditor: jest.fn(() => ({
+      destroy,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })),
+  };
+
+  const { unmount } = render(<Editor editorId="destroy-test-editor" />);
+  unmount();
+
+  expect(destroy).toHaveBeenCalledTimes(1);
+});

--- a/test/quickUnmount.test.tsx
+++ b/test/quickUnmount.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import Editor from '../src';
+
+let scriptLoadedCallback: Function;
+jest.mock('../src/loadScript', () => ({
+  loadScript: (callback: Function) => {
+    scriptLoadedCallback = callback;
+  },
+}));
+
+it('does not create the editor when unmounted before the embed script loads', () => {
+  const createEditor = jest.fn();
+  (global as any).unlayer = { createEditor };
+
+  const { unmount } = render(<Editor editorId="quick-unmount-editor" />);
+  unmount();
+
+  // Embed script finishes loading after the component is gone.
+  act(() => {
+    scriptLoadedCallback();
+  });
+
+  expect(createEditor).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

Two small bug fixes in the React wrapper's lifecycle handling:

### 1. Editor was never destroyed on unmount

The unmount cleanup in `EmailEditor.tsx` closed over `editor` from the first render, which is always `null`:

```tsx
useEffect(() => {
  return () => {
    editor?.destroy(); // editor is always null here
  };
}, []);
```

So `destroy()` was a silent no-op and every unmounted editor instance leaked (related: #272). Fixed by tracking the latest instance in a ref. Added a regression test that mounts/unmounts the editor with a mocked embed script and asserts `destroy()` is called — it fails on the old code and passes with the fix.

### 2. Broken effect dependency for event-listener props

The event-listener effect depended on `Object.keys(methodProps).join(',')`, but `methodProps` is an **array**, so this yields index strings (`"0,1,2"`) rather than prop names. Swapping one `on*` prop for another (same count) was invisible to React. Changed to `methodProps.join(',')`, which is clearly what was intended.

## Testing

- `tsdx test` — passes, including two new regression tests:
  - unmount destroys the editor (fails without fix 1)
  - unmounting before the embed script finishes loading creates no editor and doesn't throw (covers the scenario from #272)
- `tsdx build` — compiles cleanly
- `tsdx lint` — no new problems introduced (one pre-existing warning removed)