### PR TITLE
Pin @unlayer/types instead of using latest tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.11",
       "license": "MIT",
       "dependencies": {
-        "@unlayer/types": "latest"
+        "@unlayer/types": "^1.448.0"
       },
       "devDependencies": {
         "@rollup/plugin-replace": "^5.0.2",
@@ -2890,9 +2890,9 @@
       "license": "ISC"
     },
     "node_modules/@unlayer/types": {
-      "version": "1.389.0",
-      "resolved": "https://registry.npmjs.org/@unlayer/types/-/types-1.389.0.tgz",
-      "integrity": "sha512-wf46pNwwrSG0CDPsIoGYEKpmJb3aj/KFq4JOFEZK9/MfWKJFoFN2DX3s2eqiDgpG4gFrwaADjgjsmq4SHb6V5w==",
+      "version": "1.448.0",
+      "resolved": "https://registry.npmjs.org/@unlayer/types/-/types-1.448.0.tgz",
+      "integrity": "sha512-k7NhJEdp5d40pWRAp9hSpTsyjD/vCrWrinNJaZkkXRU4YK7nsa9EYvnXHmVa/TcuevmPz0JRxzi8rJ1qSfvFDw==",
       "license": "MIT"
     },
     "node_modules/abab": {
@@ -14537,9 +14537,9 @@
       }
     },
     "@unlayer/types": {
-      "version": "1.389.0",
-      "resolved": "https://registry.npmjs.org/@unlayer/types/-/types-1.389.0.tgz",
-      "integrity": "sha512-wf46pNwwrSG0CDPsIoGYEKpmJb3aj/KFq4JOFEZK9/MfWKJFoFN2DX3s2eqiDgpG4gFrwaADjgjsmq4SHb6V5w=="
+      "version": "1.448.0",
+      "resolved": "https://registry.npmjs.org/@unlayer/types/-/types-1.448.0.tgz",
+      "integrity": "sha512-k7NhJEdp5d40pWRAp9hSpTsyjD/vCrWrinNJaZkkXRU4YK7nsa9EYvnXHmVa/TcuevmPz0JRxzi8rJ1qSfvFDw=="
     },
     "abab": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   },
   "dependencies": {
-    "@unlayer/types": "latest"
+    "@unlayer/types": "^1.448.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.2",


### PR DESCRIPTION
## Summary

Fixes #469.

`package.json` currently depends on `@unlayer/types: "latest"`, which makes builds unreproducible — the resolved version can change at any time without notice, and a bad upstream publish immediately breaks consumers' installs (as reported in #469).

This pins the dependency to `^1.448.0` (the current release) and updates the lockfile accordingly.

## Testing

- `tsdx build` — compiles cleanly against `@unlayer/types@1.448.0`
- `tsdx test` — passes