### PR TITLE
Recover from embed script load failures

### DIFF
--- a/src/loadScript.ts
+++ b/src/loadScript.ts
@@ -42,6 +42,15 @@ export const loadScript = (
       loaded = true;
       runCallbacks();
     };
+    embedScript.onerror = () => {
+      // Remove the failed script tag so a later loadScript call (e.g. a
+      // remount) is able to inject and retry it; otherwise isScriptInjected
+      // keeps returning true and the editor can never load on this page.
+      embedScript.remove();
+      console.error(
+        `react-email-editor: failed to load unlayer embed script from ${scriptUrl}`
+      );
+    };
     document.head.appendChild(embedScript);
   } else {
     runCallbacks();

--- a/test/loadScript.test.ts
+++ b/test/loadScript.test.ts
@@ -1,0 +1,31 @@
+import { loadScript } from '../src/loadScript';
+
+const scriptUrl = 'https://example.com/test-embed.js';
+
+const getScript = () =>
+  document.querySelector(`script[src="${scriptUrl}"]`) as HTMLScriptElement | null;
+
+it('removes a failed script tag so a later call can retry', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  const callback = jest.fn();
+
+  loadScript(callback, scriptUrl);
+  const firstScript = getScript();
+  expect(firstScript).toBeTruthy();
+
+  // Simulate a network failure loading the embed script.
+  firstScript!.dispatchEvent(new Event('error'));
+
+  expect(getScript()).toBeNull();
+  expect(callback).not.toHaveBeenCalled();
+
+  // A subsequent call (e.g. a remount) injects the script again.
+  loadScript(callback, scriptUrl);
+  const secondScript = getScript();
+  expect(secondScript).toBeTruthy();
+
+  secondScript!.dispatchEvent(new Event('load'));
+
+  // Both queued callbacks run once the script finally loads.
+  expect(callback).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
## Summary

If the unlayer embed script fails to load (network error, CDN hiccup, ad blocker), the dead `<script>` tag currently stays in the document. Every subsequent `loadScript` call then sees `isScriptInjected()` return `true` and waits for an `onload` that will never fire — so the editor can never load again on that page, even after a remount. The failure is also completely silent.

This adds an `onerror` handler that removes the failed script tag and logs the failure. Queued callbacks stay pending, so the next `loadScript` call (e.g. a remount) re-injects the script, and everything proceeds normally once it loads.

## Testing

- New test in `test/loadScript.test.ts`: injects the script, dispatches an `error` event, asserts the tag is removed and callbacks are not run; then calls `loadScript` again, dispatches `load`, and asserts the queued callbacks fire. Fails without the fix.
- `tsdx test` / `tsdx build` — pass