### PR TITLE
fix: use useId for auto-generated editor id to fix SSR hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **SSR/hydration:** auto-generated editor ids now use React's `useId` (React 18+) so the id is identical on the server render and during client hydration. Previously the id came from a module-level counter that diverges between server and client, causing a hydration mismatch and — because the editor then mounted against a stale server id — a silently blank editor under SSR (e.g. the Next.js App Router). React 16.8/17 keep the legacy counter fallback. Pass an explicit `editorId` to opt out. ([EmailEditor.tsx](src/EmailEditor.tsx))
+
 ## 2.0.0 (2026-07-06)
 
 Modernization release. The component API is unchanged — most apps on React 16.8+ with a current toolchain can upgrade without any code changes.

--- a/src/EmailEditor.tsx
+++ b/src/EmailEditor.tsx
@@ -16,6 +16,25 @@ const win =
   typeof window === 'undefined' ? { __unlayer_lastEditorId: 0 } : window;
 win.__unlayer_lastEditorId = win.__unlayer_lastEditorId || 0;
 
+// Legacy fallback for React 16.8/17, which have no useId. Not hydration-safe,
+// but those versions predate the modern SSR story. Exercised only by the React
+// 16/17 smoke suite (npm run test:legacy), which runs without coverage.
+/* v8 ignore start */
+const useCounterEditorId = (): string =>
+  useMemo(() => `editor-${++win.__unlayer_lastEditorId}`, []);
+/* v8 ignore stop */
+
+// React 18+ exposes useId, which returns an identifier that is identical on the
+// server render and during client hydration — the correct fix for the id
+// mismatch that otherwise leaves the editor mounting against a stale server id
+// (blank editor) under SSR/Next.js. The implementation is picked once at module
+// load (stable for the app's lifetime), so the same hook runs on every render.
+const useGeneratedEditorId: () => string =
+  typeof React.useId === 'function'
+    ? // Strip ':' so the id is a valid CSS selector for unlayer.createEditor.
+      () => `editor-${React.useId().replace(/:/g, '')}`
+    : useCounterEditorId;
+
 function EmailEditorInner<
   TDisplayMode extends DisplayMode | undefined = 'email',
 >(
@@ -30,10 +49,10 @@ function EmailEditorInner<
 
   const [hasLoadedEmbedScript, setHasLoadedEmbedScript] = useState(false);
 
-  const editorId = useMemo(
-    () => props.editorId || `editor-${++win.__unlayer_lastEditorId}`,
-    [props.editorId]
-  );
+  // Always call the hook (rules of hooks); the generated id is only used when
+  // no explicit editorId prop is provided.
+  const generatedId = useGeneratedEditorId();
+  const editorId = props.editorId || generatedId;
 
   const options = {
     ...(props.options || {}),

--- a/test/ssr.test.tsx
+++ b/test/ssr.test.tsx
@@ -1,0 +1,68 @@
+import React, { act } from 'react';
+import { renderToString } from 'react-dom/server';
+import { hydrateRoot } from 'react-dom/client';
+import EmailEditor from '../src';
+
+// Resolve the embed script synchronously and stub the editor instance so the
+// mount effects run without hitting the network.
+vi.mock('../src/loadScript', () => ({
+  loadScript: (callback: Function) => callback(),
+}));
+
+// Raw react-dom (not @testing-library) is used here to control the SSR ->
+// hydrate boundary, so opt in to act() support explicitly.
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  (globalThis as any).unlayer = {
+    createEditor: vi.fn(() => ({
+      addEventListener: vi.fn(),
+      destroy: vi.fn(),
+    })),
+  };
+});
+
+const editorIdIn = (root: ParentNode) =>
+  root.querySelector<HTMLElement>('[id^="editor-"]')?.id;
+
+const parseId = (html: string) => {
+  const el = document.createElement('div');
+  el.innerHTML = html;
+  return editorIdIn(el);
+};
+
+it('derives the auto id from tree position, so repeat renders agree', () => {
+  // The old module-level counter produced a different id on every render
+  // (editor-1, editor-2, ...). Two independent renders of the same tree must
+  // now produce the same id, which is what makes server and client agree.
+  const first = renderToString(<EmailEditor />);
+  const second = renderToString(<EmailEditor />);
+
+  expect(parseId(first)).toBeTruthy();
+  expect(parseId(first)).toBe(parseId(second));
+});
+
+it('hydrates a server-rendered editor without an id mismatch', () => {
+  const serverHtml = renderToString(<EmailEditor />);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  container.innerHTML = serverHtml;
+
+  const serverId = editorIdIn(container);
+  expect(serverId).toBeTruthy();
+
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  act(() => {
+    hydrateRoot(container, <EmailEditor />);
+  });
+
+  // Same id after hydration, and React logged no hydration-mismatch warning.
+  expect(editorIdIn(container)).toBe(serverId);
+  const hydrationWarning = errorSpy.mock.calls.some((args) =>
+    args.some((a) => typeof a === 'string' && /hydrat|did not match/i.test(a))
+  );
+  expect(hydrationWarning).toBe(false);
+
+  errorSpy.mockRestore();
+  document.body.removeChild(container);
+});


### PR DESCRIPTION
## Fix SSR hydration mismatch for the auto-generated editor id

### The problem

When `<EmailEditor />` is rendered without an explicit `editorId`, the id is generated from a module-level counter:

```ts
const editorId = useMemo(
  () => props.editorId || `editor-${++win.__unlayer_lastEditorId}`,
  [props.editorId]
);
```

Under SSR this diverges between server and client:

- On a warm server the module counter persists across requests, so successive renders emit `editor-2`, `editor-3`, ….
- Every fresh browser starts at `0`, so the client computes `editor-1`.

React does not patch attribute mismatches during hydration, so the DOM keeps the server's id while the mount effect calls `unlayer.createEditor({ id: 'editor-1' })` against an element that no longer matches — the editor mounts on a missing container and **renders blank, with no error**.

This bites the Next.js App Router specifically, which this package already targets via the `'use client'` banner added in 2.0.0.

### The fix

Use React 18+'s [`useId`](https://react.dev/reference/react/useId), whose value is identical on the server render and during client hydration. React 16.8/17 (still in the peer range) have no `useId`, so they keep the legacy counter fallback. The implementation is selected once at module load, so the same hook runs on every render (rules of hooks are respected). Passing an explicit `editorId` is unaffected.

### Testing

Adds `test/ssr.test.tsx`, which renders on the server with `renderToString`, then hydrates with `hydrateRoot`, and asserts the id is stable with no hydration-mismatch warning. The test **fails on the old counter** (server/client id divergence + React hydration warning) and **passes with `useId`**.

- `npm test` — 10 passing (8 existing + 2 new)
- `npm run typecheck`, `npm run build`, `npm run lint` — clean
- `npm run test:coverage` — above thresholds (the legacy fallback is `v8 ignore`-d since it is exercised only by the React 16/17 `test:legacy` smoke suite, which runs without coverage)

### Notes

- No public API change. `editorId` still wins when provided.
- `useId` output is stripped of `:` so the generated id stays a valid CSS selector for `unlayer.createEditor`.
