### PR TITLE
Add typings for forwarded Unlayer event handlers (#497)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { CSSProperties } from 'react';
 
 import type {
   AppearanceConfig,
+  CallbackTypeMap,
   DisplayMode,
   ToolsConfig,
   UnlayerEditor,
@@ -27,6 +28,15 @@ export interface EmailEditorProps<
   };
   scriptUrl?: string | undefined;
   style?: CSSProperties | undefined;
+
+  // Any prop beginning with `on` (other than onLoad/onReady above) is
+  // forwarded to the Unlayer editor via `addEventListener`. The common
+  // handlers are typed explicitly for autocomplete and payload typing; the
+  // index signature keeps arbitrary forwarded events from erroring.
+  onDesignLoad?: CallbackTypeMap<TDisplayMode>['onDesignLoad'];
+  onDesignUpdated?: CallbackTypeMap<TDisplayMode>['design:updated'];
+  onImageUpload?: CallbackTypeMap<TDisplayMode>['onImageUpload'];
+  [event: `on${string}`]: ((...args: any[]) => void) | undefined;
 
   // redundant props -- already available in options
   /** @deprecated */

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -60,7 +60,7 @@ it('registers on* props as editor event listeners and onReady on editor:ready', 
     <EmailEditor
       editorId="test-editor"
       onReady={onReady}
-      {...({ onDesignUpdated } as any)}
+      onDesignUpdated={onDesignUpdated}
     />
   );
 


### PR DESCRIPTION
Fixes #497

## Problem

`EmailEditor` forwards any prop matching `/^on/` (other than `onLoad`/`onReady`) to the underlying Unlayer editor via `addEventListener`, but `EmailEditorProps` only declared `onLoad` and `onReady`. As a result, TypeScript consumers get errors on supported handlers such as `onDesignUpdated`, even though they work at runtime.

The gap was already visible internally: the test suite had to cast with `{...({ onDesignUpdated } as any)}` to pass these props.

## Fix

In `src/types.ts`:

- Type the common handlers explicitly (`onDesignLoad`, `onDesignUpdated`, `onImageUpload`) by reusing the payload types `@unlayer/types` already exports via `CallbackTypeMap` — consumers get autocomplete **and** a typed `data` payload.
- Add an `[event: \`on${string}\`]` index signature so any other forwarded handler is accepted without error, matching the runtime's "forward any `on*` prop" behavior.

Also removed the `as any` workaround in `test/index.test.tsx` so the suite exercises the real types.

## Verification

- `tsc --noEmit` clean; all 8 tests pass without the cast.
- Consumer-side check against the **built `dist` types** under `--strict` (React 19 + Vite, as in the report): the exact issue repro compiles, `onLoad`/`onReady` keep their precise types, and a typo'd payload field (e.g. `data.nonExistentField`) is still correctly rejected — confirming payloads aren't swallowed by the catch-all.