### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.0 (2026-08-11)
+
+### Added
+
+- **Typings for forwarded Unlayer event handlers.** `EmailEditor` forwards any `on*` prop to the underlying editor via `addEventListener`, but `EmailEditorProps` previously declared only `onLoad`/`onReady`, so TypeScript users got errors on supported handlers. The common handlers (`onDesignLoad`, `onDesignUpdated`, `onImageUpload`) are now typed explicitly with their payloads, and an `on${string}` index signature covers the rest (#497).
+
+### Changed
+
+- Resolved all outstanding security advisories in the dev/build toolchain (`esbuild`, `postcss`, `nanoid`, `undici`) via `overrides`, and bumped the demo's `react-router-dom`. No runtime dependency of the published package was affected, so there is no consumer impact.
+
 ## 2.0.0 (2026-07-06)
 
 Modernization release. The component API is unchanged — most apps on React 16.8+ with a current toolchain can upgrade without any code changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-email-editor",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-email-editor",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@unlayer/types": "^1.448.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email-editor",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Unlayer's Email Editor Component for React.js",
   "type": "commonjs",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump `2.0.0` → `2.1.0`. **Version-only change** — the actual `npm publish` / tag is done separately by the maintainer.

Minor bump because it adds new backwards-compatible public type surface (the forwarded event-handler props); no runtime behavior changed.

### Included since 2.0.0
- **Added:** typings for forwarded Unlayer event handlers — `onDesignLoad`/`onDesignUpdated`/`onImageUpload` typed with payloads plus an `on${string}` catch-all (#497 / #507).
- **Changed:** resolved dev/build-toolchain security advisories via `overrides` (#508). No runtime dependency of the published package was affected — no consumer impact.

### Changes in this PR
- `package.json` + `package-lock.json`: version → `2.1.0`
- `CHANGELOG.md`: new `2.1.0 (2026-08-11)` section

Lint passes; no code changes.

After merge, publish with:
\`\`\`
npm run release
\`\`\`
(then tag `v2.1.0`)