### PR TITLE
Fix loadScript never invoking callbacks when embed script is preloaded (#496)

### DIFF
--- a/src/loadScript.ts
+++ b/src/loadScript.ts
@@ -2,25 +2,32 @@ const defaultScriptUrl = 'https://editor.unlayer.com/embed.js?2';
 const callbacks: Function[] = [];
 let loaded = false;
 
-const isScriptInjected = (scriptUrl: string) => {
-  const scripts = document.querySelectorAll('script');
-  let injected = false;
+const findScript = (scriptUrl: string): HTMLScriptElement | null => {
+  const scripts = document.querySelectorAll<HTMLScriptElement>('script');
+  let found: HTMLScriptElement | null = null;
 
   scripts.forEach((script) => {
     if (script.src.includes(scriptUrl)) {
-      injected = true;
+      found = script;
     }
   });
 
-  return injected;
+  return found;
 };
+
+// The embed is usable once the global `unlayer` object exists. This is a more
+// reliable signal than our own onload handler, which never runs when the
+// script was injected by something other than this module.
+const isEmbedReady = () => loaded || typeof unlayer !== 'undefined';
 
 const addCallback = (callback: Function) => {
   callbacks.push(callback);
 };
 
 const runCallbacks = () => {
-  if (loaded) {
+  if (isEmbedReady()) {
+    loaded = true;
+
     let callback;
 
     while ((callback = callbacks.shift())) {
@@ -35,7 +42,9 @@ export const loadScript = (
 ) => {
   addCallback(callback);
 
-  if (!isScriptInjected(scriptUrl)) {
+  const existingScript = findScript(scriptUrl);
+
+  if (!existingScript) {
     const embedScript = document.createElement('script');
     embedScript.setAttribute('src', scriptUrl);
     embedScript.onload = () => {
@@ -43,7 +52,19 @@ export const loadScript = (
       runCallbacks();
     };
     document.head.appendChild(embedScript);
-  } else {
+    return;
+  }
+
+  // The embed script tag is already on the page -- from a previous mount, a
+  // preload in the HTML, or a parent application. If the embed has finished
+  // initializing, run queued callbacks now; otherwise wait for the existing
+  // element to finish loading (our own onload above never ran for it).
+  if (isEmbedReady()) {
     runCallbacks();
+  } else {
+    existingScript.addEventListener('load', () => {
+      loaded = true;
+      runCallbacks();
+    });
   }
 };

--- a/test/loadScript.test.ts
+++ b/test/loadScript.test.ts
@@ -41,3 +41,52 @@ it('injects a separate script tag for a custom scriptUrl', () => {
     document.querySelectorAll('script[src*="example.com/custom-embed"]').length
   ).toBe(1);
 });
+
+// These build a fresh module (resetting the `loaded` flag and callback queue)
+// so they can exercise the case where the embed script is already on the page
+// but was NOT injected by loadScript -- so its onload handler was never ours.
+describe('when the embed script is already present on the page', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.head.innerHTML = '';
+    delete (globalThis as any).unlayer;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).unlayer;
+  });
+
+  it('runs queued callbacks once a pre-existing script finishes loading', async () => {
+    const preloaded = document.createElement('script');
+    preloaded.src = 'https://editor.unlayer.com/embed.js?2';
+    document.head.appendChild(preloaded);
+
+    const { loadScript: freshLoadScript } = await import('../src/loadScript');
+    const callback = vi.fn();
+
+    freshLoadScript(callback);
+
+    // Embed not ready yet: global `unlayer` is undefined and the script we
+    // did not inject has not loaded.
+    expect(callback).not.toHaveBeenCalled();
+    expect(embedScripts().length).toBe(1); // no duplicate script injected
+
+    preloaded.dispatchEvent(new Event('load'));
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs callbacks immediately when the embed is already initialized', async () => {
+    const preloaded = document.createElement('script');
+    preloaded.src = 'https://editor.unlayer.com/embed.js?2';
+    document.head.appendChild(preloaded);
+    (globalThis as any).unlayer = {}; // embed already loaded before we mounted
+
+    const { loadScript: freshLoadScript } = await import('../src/loadScript');
+    const callback = vi.fn();
+
+    freshLoadScript(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #496

## Problem

`loadScript()` tracks readiness with a module-level `loaded` flag that is **only** set inside the `onload` handler of the `<script>` element it injects itself.

When the embed script is **already on the page** — preloaded in `index.html`, injected by a parent app, or added by another component before `EmailEditor` mounts — `loadScript` takes its "already injected" branch and calls `runCallbacks()`. But `runCallbacks()` no-ops while `loaded` is `false`, and our `onload` never ran for a script we didn't create. Result:

- The queued callback (which creates the editor) never fires → **the editor never initializes**.
- `loaded` stays `false` permanently, so **every subsequent mount also breaks**.

## Fix

Determine embed readiness from the global `unlayer` object — the same thing the component uses to create the editor — instead of relying solely on our own `onload`:

- **Script already present and embed ready** (`unlayer` defined, or we previously loaded it): run queued callbacks immediately.
- **Script already present but still loading**: attach a `load` listener to the existing element so callbacks fire when it finishes.
- **Script not present**: unchanged — inject it and run callbacks on its `onload`.

## Tests

Added two cases (each builds a fresh module so the singleton `loaded`/queue state is isolated) covering the pre-existing-script paths:

- runs queued callbacks once a pre-existing (still-loading) script finishes loading;
- runs callbacks immediately when the embed is already initialized.

Both **fail on `master`** and pass with this change. Full suite (10 tests), typecheck, lint, and build all pass.

## Note

Behavioral bug fix — warrants a patch release (e.g. `2.1.1`) whenever you next publish. No version bump included here.