### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.1 (2026-08-11)
+
+### Fixed
+
+- **`loadScript` never invoked its callbacks when the embed script was already on the page.** If the Unlayer embed was preloaded in the HTML, injected by a parent app, or added by another component before `EmailEditor` mounted, the internal `loaded` flag stayed `false`, so queued callbacks never ran and the editor never initialized (and every later mount stayed broken too). Readiness is now derived from the global `unlayer` object, with a `load` listener attached to a still-loading pre-existing script (#496).
+
 ## 2.1.0 (2026-08-11)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-email-editor",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-email-editor",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@unlayer/types": "^1.448.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-email-editor",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Unlayer's Email Editor Component for React.js",
   "type": "commonjs",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump `2.1.0` → `2.1.1`. **Version-only change** — the actual `npm publish` / tag is done separately by the maintainer.

Patch bump because it ships a behavioral bug fix with no API changes.

### Included since 2.1.0
- **Fixed:** `loadScript` never invoked its callbacks when the embed script was already present on the page (preloaded in HTML, injected by a parent app, or added by another component), so the editor never initialized — and every later mount stayed broken. Readiness is now derived from the global `unlayer` object, with a `load` listener for a still-loading pre-existing script (#496 / #510).

### Changes in this PR
- `package.json` + `package-lock.json`: version → `2.1.1`
- `CHANGELOG.md`: new `2.1.1 (2026-08-11)` section

Lint passes; no code changes.

After merge, publish with:
\`\`\`
npm run release
\`\`\`
(then tag `v2.1.1`)