### PR TITLE
Ignore TypeScript major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+    ignore:
+      # TypeScript 7 is the native rewrite; tsup's bundled rollup-plugin-dts
+      # targets the TS 5.x compiler API and cannot emit our .d.ts under it
+      # (build fails). Hold major bumps until the dts toolchain supports TS 7;
+      # minor/patch within the current major still flow.
+      - dependency-name: typescript
+        update-types: ['version-update:semver-major']
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Adds a Dependabot `ignore` rule so it stops proposing **TypeScript major** upgrades.

## Why

TypeScript 7 is the native compiler rewrite. `tsup`'s bundled `rollup-plugin-dts@6.1.1` targets the TS 5.x compiler API and **cannot emit the package's `.d.ts` under TS 7** — the build throws:

```
TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')
```

Since the published package *is* its type declarations, that's a hard blocker. Verified locally: under TS 7, typecheck and tests pass but `npm run build` fails at the DTS step.

This bump was also grouped into the `dev-dependencies` PR (#503) and turned the whole group red, blocking otherwise-safe minor/patch updates from landing.

## Change

```yaml
ignore:
  - dependency-name: typescript
    update-types: ['version-update:semver-major']
```

Scoped to **major only** — TypeScript minor/patch within the current major still flow normally. Lift this once `tsup` / `rollup-plugin-dts` support TS 7.

## Follow-up (not in this PR)
- Close #503 (can't go green while TS 7 is in the group); Dependabot will regenerate a green group on its next run.