### PR TITLE
Automate GitHub Releases on version tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+# Publishing to npm stays local (`npm run release`, using the maintainer's
+# 2FA). That command pushes a `vX.Y.Z` tag, which triggers this workflow to
+# create the matching GitHub Release from the CHANGELOG entry.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Extract changelog notes for this tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Pull the section between "## <version> (...)" and the next "## ".
+          # index()==1 matches the literal header start, so no regex escaping
+          # of the version's dots is needed.
+          awk -v h="## ${VERSION} (" '
+            index($0, h) == 1 { f = 1; next }
+            f && /^## / { exit }
+            f { print }
+          ' CHANGELOG.md > release-notes.md
+          # Fall back to a pointer if the version has no changelog section.
+          if [ ! -s release-notes.md ]; then
+            echo "See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/master/CHANGELOG.md)." > release-notes.md
+          fi
+          echo "----- release notes for ${VERSION} -----"
+          cat release-notes.md
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Mark tags containing a hyphen (e.g. v1.7.0-beta.0) as prereleases.
+          case "$GITHUB_REF_NAME" in
+            *-*) PRERELEASE="--prerelease" ;;
+            *)   PRERELEASE="" ;;
+          esac
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            $PRERELEASE

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "lint": "prettier --check .",
     "format": "prettier --write .",
     "prepare": "npm run build",
-    "release": "npm run build && npm publish",
+    "release": "npm run build && npm publish && npm run release:tag",
+    "release:tag": "git tag v$npm_package_version && git push origin v$npm_package_version",
     "netlify-build": "cd demo && npm install && npm run build"
   },
   "peerDependencies": {


### PR DESCRIPTION
Makes `npm run release` also create the GitHub Release, so npm and GitHub Releases stay in sync automatically. Publishing stays local (your 2FA); CI only handles the GitHub Release.

## Flow

Running `npm run release` locally (on `master`, after the version-bump PR is merged):
1. `npm run build`
2. `npm publish` — local, with your 2FA (unchanged)
3. **`npm run release:tag`** — `git tag vX.Y.Z && git push origin vX.Y.Z`

Pushing the `vX.Y.Z` tag triggers the new **`.github/workflows/release.yml`**, which:
- extracts the `## X.Y.Z (...)` section from `CHANGELOG.md`,
- runs `gh release create vX.Y.Z` with those notes (via the built-in `GITHUB_TOKEN`),
- marks the release as a prerelease if the tag contains a hyphen (e.g. `v1.7.0-beta.0`),
- falls back to a CHANGELOG link if no matching section exists.

So going forward there's still **one command** — the GitHub Release appears on its own once the tag lands.

## Changes
- `package.json`: `release` now appends `npm run release:tag`; new `release:tag` script.
- `.github/workflows/release.yml`: new, `on: push: tags: ['v*']`, `permissions: contents: write`.

## Validated locally
- `npm_package_version` resolves in the script env → `git tag v2.1.2 && git push origin v2.1.2`.
- CHANGELOG extraction verified for a single-section version (2.1.2) and a multi-section one (2.1.0 → Added + Changed, stopping before 2.0.0).
- Prettier clean.

## Notes
- Publish order is publish-then-tag, so a failed/cancelled `npm publish` won't leave a dangling tag.
- Existing tags (`v2.0.0`, `v2.1.2`) are untouched; automation applies to the next release (`2.1.3`+).
- Not included: moving npm publish into CI via an OIDC Trusted Publisher (would make it fully hands-off but needs registering the publisher on npmjs.com). Easy follow-up if you want it later.